### PR TITLE
Add Docker dev profile for live TypeScript editing

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,21 @@
 
 **To access the website, visit http://localhost:8080**
 
+### Frontend live-reload during development
+
+When you want to iterate on the TypeScript sources without rebuilding the
+containers, start the Vite dev server profile:
+
+```bash
+docker compose --profile dev up frontend-dev
+```
+
+This boots a container that mounts `srcs/frontend` from your host and exposes
+Vite on http://localhost:5173 with hot-module replacement.
+
+Files saved under `srcs/frontend` (including `.ts` files) are recompiled and
+refreshed automatically.
+
 If you don't have a clue how anything works, this very simple pong game gives a good idea of the basic stuff:
 
 https://www.geeksforgeeks.org/javascript/pong-game-in-javascript/

--- a/srcs/docker-compose.yml
+++ b/srcs/docker-compose.yml
@@ -1,4 +1,22 @@
 services:
+  frontend-dev:
+    build:
+      context: .
+      dockerfile: requirements/nginx/Dockerfile
+      target: dev
+    command: sh -c "npm install && npm run dev -- --host 0.0.0.0 --port 5173 --strictPort"
+    environment:
+      CHOKIDAR_USEPOLLING: "true"
+      WATCHPACK_POLLING: "true"
+    ports:
+      - "127.0.0.1:5173:5173"
+    volumes:
+      - ./frontend:/app/frontend
+      - /app/frontend/node_modules
+    networks:
+      - transcendence
+    profiles: ["dev"]
+
   nginx:
     build:
       context: .

--- a/srcs/requirements/nginx/Dockerfile
+++ b/srcs/requirements/nginx/Dockerfile
@@ -1,5 +1,5 @@
-# Stage 1: Build frontend with Node
-FROM node:18-alpine AS builder
+# Stage 1: install frontend dependencies once so later stages can reuse them
+FROM node:18-alpine AS base
 
 WORKDIR /app/frontend
 
@@ -7,13 +7,29 @@ WORKDIR /app/frontend
 COPY frontend/package*.json frontend/tsconfig.json ./
 RUN npm install
 
+# Stage 2: development server (exposed through docker compose with target=dev)
+FROM base AS dev
+
+# Copy the whole project. When running with a bind mount the host files will
+# overwrite the copy, but having the sources in the image keeps the dev image
+# usable without a mount.
+COPY frontend/ ./
+
+ENV HOST=0.0.0.0 \
+    PORT=5173
+
+CMD ["npm", "run", "dev", "--", "--host", "0.0.0.0", "--port", "5173", "--strictPort"]
+
+# Stage 3: Build frontend with Node for production
+FROM base AS builder
+
 # Copy sources
 COPY frontend/ ./
 
 # Run full build (TypeScript + Tailwind + bundler)
 RUN npm run build
 
-# Stage 2: Minimal Nginx serving compiled assets
+# Stage 4: Minimal Nginx serving compiled assets
 FROM alpine:3.21
 
 RUN apk add --no-cache nginx


### PR DESCRIPTION
## Summary
- add a development-target stage to the frontend Dockerfile so the same image can run Vite in watch mode
- extend docker-compose with a `frontend-dev` service that mounts the sources, installs deps, and runs the Vite dev server with polling
- document how to start the new hot-reload workflow in the README

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d55bb37c04832fa904c4be41e661dd