### PR TITLE
Add Makefile target for frontend dev mode

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,6 +31,10 @@ up:
 	$(DC) up -d
 	@echo "$(GREEN)Ok!$(RESET)"
 
+dev:
+	@echo "$(YELLOW)Starting frontend dev container...$(RESET)"
+	$(DC) --profile dev up --build frontend-dev
+
 re: fclean all
 
-.PHONY: all clean fclean ts build up re
+.PHONY: all clean fclean ts build up dev re

--- a/README.md
+++ b/README.md
@@ -2,6 +2,36 @@
 
 **To access the website, visit http://localhost:8080**
 
+### Frontend live-reload during development
+
+When you want to iterate on the TypeScript sources without rebuilding the
+containers, follow these steps:
+
+1. From the repository root run the dev profile:
+
+   ```bash
+   docker compose --profile dev up frontend-dev
+   ```
+
+   Add `--build` the first time (or whenever you change dependencies) to make
+   sure the image is up to date.
+
+2. Wait for Vite to report `Local:   http://localhost:5173/` in the logs.
+   This container automatically installs dependencies and enables polling so
+   file changes on your host are picked up.
+
+3. Open http://localhost:5173 in your browser. The default nginx site served
+   on port 8080 is untouched, so you can keep both running if needed.
+
+4. Edit files under `srcs/frontend` (including `.ts` files). Saving a file
+   triggers a live reload without rebuilding the containers.
+
+Stop the dev server with `Ctrl+C` and remove the container with:
+
+```bash
+docker compose --profile dev down
+```
+
 If you don't have a clue how anything works, this very simple pong game gives a good idea of the basic stuff:
 
 https://www.geeksforgeeks.org/javascript/pong-game-in-javascript/

--- a/srcs/docker-compose.yml
+++ b/srcs/docker-compose.yml
@@ -1,4 +1,22 @@
 services:
+  frontend-dev:
+    build:
+      context: .
+      dockerfile: requirements/nginx/Dockerfile
+      target: dev
+    command: sh -c "npm install && npm run dev -- --host 0.0.0.0 --port 5173 --strictPort"
+    environment:
+      CHOKIDAR_USEPOLLING: "true"
+      WATCHPACK_POLLING: "true"
+    ports:
+      - "127.0.0.1:5173:5173"
+    volumes:
+      - ./frontend:/app/frontend
+      - /app/frontend/node_modules
+    networks:
+      - transcendence
+    profiles: ["dev"]
+
   nginx:
     build:
       context: .

--- a/srcs/requirements/nginx/Dockerfile
+++ b/srcs/requirements/nginx/Dockerfile
@@ -1,5 +1,5 @@
-# Stage 1: Build frontend with Node
-FROM node:18-alpine AS builder
+# Stage 1: install frontend dependencies once so later stages can reuse them
+FROM node:18-alpine AS base
 
 WORKDIR /app/frontend
 
@@ -7,13 +7,29 @@ WORKDIR /app/frontend
 COPY frontend/package*.json frontend/tsconfig.json ./
 RUN npm install
 
+# Stage 2: development server (exposed through docker compose with target=dev)
+FROM base AS dev
+
+# Copy the whole project. When running with a bind mount the host files will
+# overwrite the copy, but having the sources in the image keeps the dev image
+# usable without a mount.
+COPY frontend/ ./
+
+ENV HOST=0.0.0.0 \
+    PORT=5173
+
+CMD ["npm", "run", "dev", "--", "--host", "0.0.0.0", "--port", "5173", "--strictPort"]
+
+# Stage 3: Build frontend with Node for production
+FROM base AS builder
+
 # Copy sources
 COPY frontend/ ./
 
 # Run full build (TypeScript + Tailwind + bundler)
 RUN npm run build
 
-# Stage 2: Minimal Nginx serving compiled assets
+# Stage 4: Minimal Nginx serving compiled assets
 FROM alpine:3.21
 
 RUN apk add --no-cache nginx


### PR DESCRIPTION
## Summary
- add a `dev` make target that boots the frontend development container with the dev profile
- include the new target in the Makefile's phony list

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d55bb37c04832fa904c4be41e661dd